### PR TITLE
Turn LanguageModel into protocol (interface in CSharp).

### DIFF
--- a/Megrez.Tests/Megrez.Tests.csproj
+++ b/Megrez.Tests/Megrez.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.2.4</ReleaseVersion>
+    <ReleaseVersion>1.2.5</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Megrez.Tests/MegrezTests.cs
+++ b/Megrez.Tests/MegrezTests.cs
@@ -180,8 +180,9 @@ public class SimpleLM : LanguageModel {
       }
     }
   }
-  public override List<Unigram> UnigramsFor(string key) => _database.ContainsKey(key) ? _database[key] : new();
-  public override bool HasUnigramsFor(string key) => _database.ContainsKey(key);
+  public List<Bigram> BigramsForKeys(string precedingKey, string key) { return new(); }
+  public List<Unigram> UnigramsFor(string key) => _database.ContainsKey(key) ? _database[key] : new();
+  public bool HasUnigramsFor(string key) => _database.ContainsKey(key);
 }
 
 public class TestClass {

--- a/Megrez.sln
+++ b/Megrez.sln
@@ -52,6 +52,6 @@ Global
 		$0.DotNetNamingPolicy = $4
 		$4.DirectoryNamespaceAssociation = PrefixedHierarchical
 		$0.StandardHeader = $5
-		version = 1.2.4
+		version = 1.2.5
 	EndGlobalSection
 EndGlobal

--- a/Megrez/5_LanguageModel.cs
+++ b/Megrez/5_LanguageModel.cs
@@ -28,44 +28,29 @@ using System.Linq;
 
 namespace Megrez {
 /// <summary>
-/// 語言模型框架，回頭實際使用時需要派生一個型別、且重寫相關函式。
+/// 語言模型框架協定，實際使用時需要派生一個型別、且重寫相關函式。
 /// </summary>
-public class LanguageModel {
-  /// <summary>
-  /// 語言模型框架，回頭實際使用時需要派生一個型別、且重寫相關函式。
-  /// </summary>
-  public LanguageModel() {}
-
-  // This function works merely as a placeholder.
-  // Please override this function to implement your own methods.
+public interface LanguageModel {
   /// <summary>
   /// 給定鍵，讓語言模型找給一組單元圖陣列。
   /// </summary>
   /// <param name="key">給定鍵。</param>
   /// <returns>一組單元圖陣列。</returns>
-  public virtual List<Unigram> UnigramsFor(string key) {
-    return key.Length == 0 ? new List<Unigram>().ToList() : new();
-  }
+  public List<Unigram> UnigramsFor(string key);
 
-  // This function works merely as a placeholder.
-  // Please override this function to implement your own methods.
   /// <summary>
   /// 給定當前鍵與前述鍵，讓語言模型找給一組雙元圖陣列。
   /// </summary>
   /// <param name="precedingKey">前述鍵。</param>
   /// <param name="key">當前鍵。</param>
   /// <returns>一組雙元圖陣列。</returns>
-  public virtual List<Bigram> BigramsForKeys(string precedingKey, string key) {
-    return precedingKey == key ? new List<Bigram>().ToList() : new();
-  }
+  public List<Bigram> BigramsForKeys(string precedingKey, string key);
 
-  // This function works merely as a placeholder.
-  // Please override this function to implement your own methods.
   /// <summary>
   /// 給定鍵，確認是否有單元圖記錄在庫。
   /// </summary>
   /// <param name="key">給定鍵。</param>
   /// <returns>True 則表示在庫，False 則表示不在庫。</returns>
-  public virtual bool HasUnigramsFor(string key) { return key.Length != 0; }
+  public bool HasUnigramsFor(string key);
 }
 }

--- a/Megrez/Megrez.csproj
+++ b/Megrez/Megrez.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <ReleaseVersion>1.2.4</ReleaseVersion>
+    <ReleaseVersion>1.2.5</ReleaseVersion>
     <PackageId>vChewing.Megrez</PackageId>
     <Authors>Shiki Suen</Authors>
     <Company>Atelier Inmu</Company>
     <Copyright>(c) 2022 and onwards The vChewing Project (MIT-NTL License).</Copyright>
     <RepositoryUrl>https://github.com/ShikiSuen/MegrezNT</RepositoryUrl>
     <NeutralLanguage>zh-TW</NeutralLanguage>
-    <AssemblyVersion>1.2.4</AssemblyVersion>
-    <FileVersion>1.2.4</FileVersion>
-    <Version>1.2.4</Version>
+    <AssemblyVersion>1.2.5</AssemblyVersion>
+    <FileVersion>1.2.5</FileVersion>
+    <Version>1.2.5</Version>
     <Product>Megrez</Product>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Reason: C# does not support inheriting from multiple classes at once.
Note: the Swift version of Megrez should also implement this change. Planning to do this in (estimate) no later than September.